### PR TITLE
Exclude schema.rb from RuboCop validation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
   Exclude:
     - 'bin/*'
     - 'vendor/**/*'
+    - 'db/schema.rb'
 
 Documentation:
   Enabled: false


### PR DESCRIPTION
This file is autogenerated and fails validation