### PR TITLE
Use an ActiveJob job to send the mailer

### DIFF
--- a/app/jobs/output_document_mailer_job.rb
+++ b/app/jobs/output_document_mailer_job.rb
@@ -1,0 +1,6 @@
+class OutputDocumentMailerJob < ActiveJob::Base
+  def perform(appointment_summary)
+    output_document = OutputDocument.new(appointment_summary)
+    OutputDocumentMailer.issue(appointment_summary, output_document.pdf).deliver_now
+  end
+end

--- a/app/services/issue_output_document.rb
+++ b/app/services/issue_output_document.rb
@@ -8,8 +8,6 @@ class IssueOutputDocument
   def call
     return unless @appointment_summary.email_address.present?
 
-    output_document = OutputDocument.new(@appointment_summary)
-    OutputDocumentMailer.issue(@appointment_summary, output_document.pdf)
-      .deliver_later
+    OutputDocumentMailerJob.perform_later(@appointment_summary)
   end
 end

--- a/features/step_definitions/record_of_guidance_steps.rb
+++ b/features/step_definitions/record_of_guidance_steps.rb
@@ -18,5 +18,5 @@ Then(/^a record of guidance document is created$/) do
 end
 
 Then(/^emailed to the customer$/) do
-  expect(ActiveJob::Base.queue_adapter.enqueued_jobs.first[:args][0]).to eql('OutputDocumentMailer')
+  expect(ActiveJob::Base.queue_adapter.enqueued_jobs.first[:job]).to eql(OutputDocumentMailerJob)
 end

--- a/spec/jobs/output_document_mailer_job_spec.rb
+++ b/spec/jobs/output_document_mailer_job_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe OutputDocumentMailerJob, '#perform' do
+  let(:appointment_summary) { double }
+  let(:output_document_pdf) { double }
+  let(:output_document) { instance_double(OutputDocument, pdf: output_document_pdf) }
+  let(:output_document_mailer) { double(deliver_now: true) }
+
+  subject(:perform_job) { described_class.new.perform(appointment_summary) }
+
+  before do
+    allow(OutputDocument).to receive(:new).with(appointment_summary).and_return(output_document)
+  end
+
+  it 'delivers the mail' do
+    expect(OutputDocumentMailer).to receive(:issue)
+      .with(appointment_summary, output_document_pdf)
+      .and_return(output_document_mailer)
+    perform_job
+  end
+end

--- a/spec/services/issue_output_document_spec.rb
+++ b/spec/services/issue_output_document_spec.rb
@@ -3,19 +3,12 @@ require 'rails_helper'
 RSpec.describe IssueOutputDocument, '#call' do
   let(:email_address) { '' }
   let(:appointment_summary) { instance_double(AppointmentSummary, email_address: email_address) }
-  let(:output_document_pdf) { double }
-  let(:output_document) { instance_double(OutputDocument, pdf: output_document_pdf) }
-  let(:output_document_mailer) { double(deliver_later: true) }
 
   subject(:call_service) { described_class.new(appointment_summary).call }
 
-  before do
-    allow(OutputDocument).to receive(:new).with(appointment_summary).and_return(output_document)
-  end
-
   context 'without an email address' do
     it 'does not issue the output document' do
-      expect(OutputDocumentMailer).to_not receive(:issue)
+      expect(OutputDocumentMailerJob).to_not receive(:perform_later)
       call_service
     end
   end
@@ -24,9 +17,8 @@ RSpec.describe IssueOutputDocument, '#call' do
     let(:email_address) { 'a@b.com' }
 
     it 'issues the output document' do
-      expect(OutputDocumentMailer).to receive(:issue)
-        .with(appointment_summary, output_document_pdf)
-        .and_return(output_document_mailer)
+      expect(OutputDocumentMailerJob).to receive(:perform_later)
+        .with(appointment_summary)
       call_service
     end
   end


### PR DESCRIPTION
Relying on the built in `ActiveJob`/`ActionMailer` magic meant the PDF attachment for the mail was being generated and then stuck into Redis for later delivery via the Sidekiq worker. Needless to say Redis didn't like this.

This PR adds yet another layer of indirection to the process and I don't like that we have an `AppointmentSummary` being passed around so many times but it should be good enough for the time being.