### PR TITLE
Collect postal address of appointment attendee

### DIFF
--- a/app/assets/stylesheets/base/_forms.css.scss
+++ b/app/assets/stylesheets/base/_forms.css.scss
@@ -20,6 +20,10 @@ input[type="date"] {
   padding: .5em;
 }
 
+textarea {
+  padding: .5em;
+}
+
 fieldset {
   margin: 0;
   padding: 0;

--- a/app/controllers/appointment_summaries_controller.rb
+++ b/app/controllers/appointment_summaries_controller.rb
@@ -30,11 +30,11 @@ class AppointmentSummariesController < ApplicationController
   private
 
   def appointment_summary_params
-    params.require(:appointment_summary).permit(:name, :email_address, :date_of_appointment,
-                                                :value_of_pension_pots, :income_in_retirement,
-                                                :guider_name, :guider_organisation,
-                                                :continue_working, :unsure, :leave_inheritance,
-                                                :wants_flexibility, :wants_security,
-                                                :wants_lump_sum, :poor_health)
+    params.require(:appointment_summary).permit(:name, :email_address, :address,
+                                                :date_of_appointment, :value_of_pension_pots,
+                                                :income_in_retirement, :guider_name,
+                                                :guider_organisation, :continue_working, :unsure,
+                                                :leave_inheritance, :wants_flexibility,
+                                                :wants_security, :wants_lump_sum, :poor_health)
   end
 end

--- a/app/views/appointment_summaries/new.html.erb
+++ b/app/views/appointment_summaries/new.html.erb
@@ -25,6 +25,11 @@
   </div>
 
   <div class="l-form-row">
+    <%= f.label :address, 'Postal address' %>
+    <%= f.text_area :address, cols: 40, rows: 6, class: 't-address' %>
+  </div>
+
+  <div class="l-form-row">
     <%= f.label :date_of_appointment %>
     <%= f.date_field :date_of_appointment, class: 't-date-of-appointment' %>
   </div>

--- a/features/step_definitions/record_of_guidance_steps.rb
+++ b/features/step_definitions/record_of_guidance_steps.rb
@@ -3,6 +3,7 @@ When(/^appointment details are captured$/) do
   page.load
   page.name.set 'Joe Bloggs'
   page.email_address.set 'joe.bloggs@example.com'
+  page.address.set "HM Treasury\n1 Horse Guards Road\nLondon\nSW1A 2HQ"
   page.date_of_appointment.set '05/02/2015'
   page.value_of_pension_pots.set 35_000
   page.income_in_retirement_pension.set true

--- a/features/support/pages/appointment_summary_page.rb
+++ b/features/support/pages/appointment_summary_page.rb
@@ -3,6 +3,7 @@ class AppointmentSummaryPage < SitePrism::Page
 
   element :name, '.t-name'
   element :email_address, '.t-email-address'
+  element :address, '.t-address'
   element :date_of_appointment, '.t-date-of-appointment'
   element :value_of_pension_pots, '.t-value-of-pension-pots'
   element :income_in_retirement_pension, '.t-income-in-retirement-pension'


### PR DESCRIPTION
I've reviewed the GDS Service Manual guidance on addresses here - https://www.gov.uk/service-manual/user-centred-design/resources/patterns/addresses

Opted for the simplest approach initially which is a text box to collect the address. We may need to break this down into individual address lines later on when we establish requirements with the print provider.

**Needs to be rebased once #21 has been merged.**