### PR TITLE
[DO NOT MERGE] Use Princely rather than WickedPDF to generate PDFs

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -3,6 +3,8 @@
 scss_files: 'app/assets/stylesheets/**/*.css.scss'
 
 exclude:
+  - '.downloads/**/*'
+  - 'lib/prince/**/*'
   - 'node_modules/**/*'
   - 'vendor/assets/**/*'
   - 'vendor/bundle/**/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 cache:
   bundler: true
   directories:
+  - .downloads
   - node_modules
   - tmp/cache/assets/test
   - vendor/assets/bower_components
@@ -11,9 +12,13 @@ env:
   - secure: OHty0sCWbCAsxw8vLWmQLe2uBu8aR7zwKXh4aO8XipkNqIQSyVF3Q/iNC2DOclOmomT/C2wp2XWLysazJ5oyYpkooTe0wh9Bl2I3J6JqF7aynLzmk8eT0BoP/MZwX0lbCI11Z2JVW349xipku/vBVoucN40P6j5FfgZjTJYm5JE=
   - secure: SVw7sxOncYt1Tp9QoPLmKSw2IxpF1u3UyfmxIG3hqjkCVrNjYTehBfnS/pxoGVugrq8q9PQ9uJPZlmOp5IKIlJhyZ6kdpq2LjRxjgAPC935qOEgsu4OM1olE0G1oqdyDBv/tePmJFmr0ViUfCIIv464g+cYd81kFzcwaeXgKjOM=
   - DATABASE_URL=postgres://postgres@localhost:5432/travis_ci_test
+  - PATH=$PWD/bin:$PATH
 node_js:
 - '0.10'
 before_script:
+- '[ -d .downloads ] || mkdir .downloads'
+- (cd .downloads; [ -d prince-9.0r5-linux-amd64-static ] || curl -s http://www.princexml.com/download/prince-9.0r5-linux-amd64-static.tar.gz | tar xzf -)
+- echo $PWD | ./.downloads/prince-9.0r5-linux-amd64-static/install.sh
 - npm install
 - ./bin/rake db:setup RAILS_ENV=test
 after_script:

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'jc-validates_timeliness'
 gem 'meta-tags'
 gem 'newrelic_rpm'
 gem 'pg'
+gem 'princely'
 gem 'puma'
 gem 'rails', '4.2.0'
 gem 'rails-i18n', '~> 4.0.0'
@@ -18,7 +19,6 @@ gem 'sass-rails', '~> 5.0'
 gem 'sidekiq'
 gem 'sinatra', require: nil # Sidekiq UI
 gem 'uglifier', '>= 1.3.0'
-gem 'wicked_pdf'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,6 +369,7 @@ GEM
       ttfunk
     pg (0.18.1)
     powerpack (0.0.9)
+    princely (1.4.1)
     puma (2.11.0)
       rack (>= 1.1, < 2.0)
     rack (1.6.0)
@@ -500,8 +501,6 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (~> 4.0)
       sprockets-rails (>= 2.0, < 4.0)
-    wicked_pdf (0.11.0)
-      rails
     wkhtmltopdf-binary (0.9.9.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
@@ -524,6 +523,7 @@ DEPENDENCIES
   newrelic_rpm
   pdf-inspector
   pg
+  princely
   puma
   rails (= 4.2.0)
   rails-i18n (~> 4.0.0)
@@ -542,5 +542,4 @@ DEPENDENCIES
   spring-commands-rspec
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
-  wicked_pdf
   wkhtmltopdf-binary

--- a/app/domain/output_document.rb
+++ b/app/domain/output_document.rb
@@ -10,7 +10,7 @@ class OutputDocument
   end
 
   def pdf
-    WickedPdf.new.pdf_from_string(html)
+    Princely.new.pdf_from_string(html)
   end
 
   private


### PR DESCRIPTION
This brings with it a dependency on PrinceXML which will require a [commercial licence](http://www.princexml.com/purchase/).

We have [a buildpack](https://github.com/guidance-guarantee-programme/heroku-buildpack-princexml) to install PrinceXML on Heroku which will need modified to use the licence file once we have it.